### PR TITLE
Drop docker from image

### DIFF
--- a/Dockerfile-nts
+++ b/Dockerfile-nts
@@ -87,7 +87,6 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` \
     && mv /*.so "$EXTENSION_DIR/" \
     && docker-php-ext-enable meminfo \
     && apk add --no-cache \
-        docker \
         py-pip \
         python-dev \
         libffi-dev \
@@ -102,8 +101,6 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` \
 # Install Xdebug and development specific configuration
     && docker-php-dev-mode xdebug \
     && docker-php-dev-mode config \
-# Install Docker and Docker Compose
-    && pip install docker-compose \
 # Forcefully clear API cache
     && rm -rf /var/cache/apk/*
 

--- a/Dockerfile-zts
+++ b/Dockerfile-zts
@@ -108,7 +108,6 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` \
     && mv /*.so "$EXTENSION_DIR/" \
     && docker-php-ext-enable meminfo \
     && apk add --no-cache \
-        docker \
         py-pip \
         python-dev \
         libffi-dev \
@@ -123,8 +122,6 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` \
 # Install Xdebug and development specific configuration
     && docker-php-dev-mode xdebug \
     && docker-php-dev-mode config \
-# Install Docker and Docker Compose
-    && pip install docker-compose \
 # Forcefully clear API cache
     && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
AFAIK no one is using it, and it's not documented so not considering it
a feature. (Also it's taking up a ton of space in the image.)