### PR TITLE
Add PHP 7.2 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,13 @@ BUILDINGIMAGE=*
 # Docker PHP images build matrix ./build-php.sh (nts/zts) (PHP version) (Alpine version)
 build-nts: BUILDINGIMAGE=nts
 build-nts: clean-tags
+	./build-php.sh cli nts 7.2 3.10
 	./build-php.sh cli nts 7.3 3.10
 	./build-php.sh cli nts 7.4 3.10
 
 build-zts: BUILDINGIMAGE=zts
 build-zts: clean-tags
+	./build-php.sh zts zts 7.2 3.10
 	./build-php.sh zts zts 7.3 3.10
 	./build-php.sh zts zts 7.4 3.10
 


### PR DESCRIPTION
Mainly out of interest to see if this would work, but if it works this paces the way to have images of all support PHP versions updated weekly until they go EOL