### PR TITLE
Run scheduled build 6 times a day to be hyper up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron:  '33 7 * * *'
+    - cron:  '33 */4 * * *'
 jobs:
   generate-alpine-strategy:
     name: Generate Alpine


### PR DESCRIPTION
Note that due to recent updates, this only results in a few seconds of build time. And with the recent instability of Github Actions this means we don't have to intentionally wait a week before an update to the latest version has been build.