### PR TITLE
Check mark job for combining require status into 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,16 @@ jobs:
       - run: docker load --input ./docker-image/image.tar
       - run: make $(php -r 'echo "test-", explode("-", str_replace(["zts-zts", "cli-nts"], ["zts", "nts"], "${{ matrix.image }}"))[0];')
       - run: rm -Rf ./docker-image/
+  check-mark:
+    name: ✔️
+    needs:
+      - lint
+      - build
+      - scan-vulnerability
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "✔️"
   push:
     name: Pushing "${{ matrix.image }}" to ${{ matrix.registry }}
     if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master'


### PR DESCRIPTION
With the ever changing matrix of PHP and Alpine versions it is a hassle
to keep changing the required statuses for branch protection. By
combining them into one it will be a lot less of a burden to update them