### PR TITLE
Introduce slim images

### DIFF
--- a/Dockerfile-nts-alpine
+++ b/Dockerfile-nts-alpine
@@ -13,7 +13,7 @@ RUN git fetch \
     cp "$EXTENSION_DIR/uv.so" /uv.so
 RUN sha256sum /uv.so
 
-FROM php:7.4-cli-alpine3.11 AS nts-root
+FROM php:7.4-cli-alpine3.11 AS nts-slim-root
 
 # Build-time metadata as defined at http://label-schema.org
 LABEL org.label-schema.name="wyrihaximusnet/php" \
@@ -42,9 +42,6 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
 	mv /*.so "$EXTENSION_DIR/" && \
 	apk update && \
 	apk add --no-cache \
-        freetype-dev \
-        libjpeg-turbo-dev \
-        libpng-dev \
         gmp-dev \
         zlib-dev \
         postgresql-dev \
@@ -52,17 +49,12 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
         libuv-dev \
         coreutils \
         procps \
-        vips-dev \
         git \
         $PHPIZE_DEPS \
     ## Install PECL
     && wget pear.php.net/go-pear.phar && php go-pear.phar \
-    ## Initially this was an if statement to check for PHP 7.4, but since then the situation change so we're just going to try both to avoid the conditional growing out of hand
-    && (docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/) \
-    && docker-php-ext-install -j$(nproc) gd pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache \
-    && pecl install vips \
+    && docker-php-ext-install -j$(nproc) pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache \
     && docker-php-ext-enable uv \
-    && docker-php-ext-enable vips \
     && apk del $PHPIZE_DEPS \
     && wget -O - https://raw.githubusercontent.com/eficode/wait-for/master/wait-for > /bin/wait-for \
     && chmod +x /bin/wait-for \
@@ -78,40 +70,56 @@ STOPSIGNAL SIGTERM
 ENTRYPOINT ["/usr/local/bin/shush", "exec", "docker-php-entrypoint"]
 
 ## NTS-DEV STAGE ##
+FROM nts-slim-root AS nts-root
+
+# Install ext-gd and ext-vips
+COPY src/php/utils/docker/alpine/install-gd-and-vips /usr/local/bin/install-gd-and-vips
+RUN install-gd-and-vips && rm -rf /usr/local/bin/install-gd-and-vips
+
+## NTS-DEV STAGE ##
+FROM nts-slim-root AS nts-slim-dev-root
+
+RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
+
+# Install docker help scripts
+COPY src/php/utils/docker/alpine/dev-mode /usr/local/bin/dev-mode
+COPY src/php/utils/docker/alpine/docker-php-dev-mode /usr/local/bin/docker-php-dev-mode
+RUN dev-mode && rm -rf /usr/local/bin/dev-mode && rm -rf /usr/local/bin/docker-php-dev-mode
+
+# Install composer
+COPY src/php/utils/install-composer /usr/local/bin/
+RUN install-composer && rm -rf /usr/local/bin/install-composer
+
+# Change entrypoint back to the default because we don't need shush in development
+ENTRYPOINT ["docker-php-entrypoint"]
+
+## NTS-DEV STAGE ##
 FROM nts-root AS nts-dev-root
 
 RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
 
 # Install docker help scripts
-COPY src/php/utils/docker/alpine/ /usr/local/bin/
-
-RUN apk add --no-cache \
-        make \
-        git \
-        openssh-client \
-        bash \
-        strace \
-        gdb \
-# Install Xdebug and development specific configuration
-    && docker-php-dev-mode xdebug \
-    && docker-php-dev-mode config \
-# Forcefully clear API cache
-    && rm -rf /var/cache/apk/*
+COPY src/php/utils/docker/alpine/dev-mode /usr/local/bin/dev-mode
+COPY src/php/utils/docker/alpine/docker-php-dev-mode /usr/local/bin/docker-php-dev-mode
+RUN dev-mode && rm -rf /usr/local/bin/dev-mode && rm -rf /usr/local/bin/docker-php-dev-mode
 
 # Install composer
 COPY src/php/utils/install-composer /usr/local/bin/
-RUN install-composer \
-    && rm -rf /usr/local/bin/install-composer
+RUN install-composer && rm -rf /usr/local/bin/install-composer
 
 # Change entrypoint back to the default because we don't need shush in development
 ENTRYPOINT ["docker-php-entrypoint"]
 
 ## NTS-DEV stage ##
-FROM nts-dev-root AS nts-dev
+FROM nts-slim-dev-root AS nts-slim-dev
+USER app
 
+FROM nts-dev-root AS nts-dev
 USER app
 
 ## NTS stage ##
-FROM nts-root AS nts
+FROM nts-slim-root AS nts-slim
+USER app
 
+FROM nts-root AS nts
 USER app

--- a/Dockerfile-nts-debian
+++ b/Dockerfile-nts-debian
@@ -13,7 +13,7 @@ RUN git fetch \
     cp "$EXTENSION_DIR/uv.so" /uv.so
 RUN sha256sum /uv.so
 
-FROM php:7.4-cli-buster AS nts-root
+FROM php:7.4-cli-buster AS nts-slim-root
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
@@ -49,9 +49,6 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
 	apt-get update && \
 	yes | apt-get upgrade && \
     yes | apt-get install \
-        libfreetype6-dev \
-        libjpeg62-turbo-dev \
-        libpng-dev \
         libgmp-dev \
         zlib1g-dev \
         libpq-dev \
@@ -63,16 +60,12 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
         bash \
         coreutils \
         procps \
-        libvips-dev \
         git \
         wget \
         gdb \
         $PHPIZE_DEPS \
-    && (docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/) \
-    && docker-php-ext-install -j$(nproc) gd pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv \
-    && pecl install vips \
+    && docker-php-ext-install -j$(nproc) pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv \
     && docker-php-ext-enable uv \
-    && docker-php-ext-enable vips \
     && wget -O - https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /bin/wait-for \
     && yes | apt-get purge wget $PHPIZE_DEPS \
     && chmod +x /bin/wait-for \
@@ -87,26 +80,22 @@ STOPSIGNAL SIGTERM
 
 ENTRYPOINT ["/usr/local/bin/shush", "exec", "docker-php-entrypoint"]
 
-## nts-DEV STAGE ##
-FROM nts-root AS nts-dev-root
+## NTS-DEV STAGE ##
+FROM nts-slim-root AS nts-root
+
+# Install ext-gd and ext-vips
+COPY src/php/utils/docker/debian/install-gd-and-vips /usr/local/bin/install-gd-and-vips
+RUN install-gd-and-vips && rm -rf /usr/local/bin/install-gd-and-vips
+
+## NTS-DEV STAGE ##
+FROM nts-slim-root AS nts-slim-dev-root
 
 RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
 
 # Install docker help scripts
-COPY src/php/utils/docker/ /usr/local/bin/
-
-RUN apt-get update \
-    && yes | apt-get install \
-        make \
-        git \
-        openssh-client \
-        bash \
-        strace \
-# Install Xdebug and development specific configuration
-    && docker-php-dev-mode xdebug \
-    && docker-php-dev-mode config \
-# Forcefully clear API cache
-    && rm -rf /var/cache/apk/*
+COPY src/php/utils/docker/debian/dev-mode /usr/local/bin/dev-mode
+COPY src/php/utils/docker/debian/docker-php-dev-mode /usr/local/bin/docker-php-dev-mode
+RUN dev-mode && rm -rf /usr/local/bin/dev-mode && rm -rf /usr/local/bin/docker-php-dev-mode
 
 # Install composer
 COPY src/php/utils/install-composer /usr/local/bin/
@@ -119,12 +108,37 @@ RUN apt-get update \
 # Change entrypoint back to the default because we don't need shush in development
 ENTRYPOINT ["docker-php-entrypoint"]
 
-## nts-DEV stage ##
-FROM nts-dev-root AS nts-dev
+## NTS-DEV STAGE ##
+FROM nts-root AS nts-dev-root
 
+RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
+
+# Install docker help scripts
+COPY src/php/utils/docker/debian/dev-mode /usr/local/bin/dev-mode
+COPY src/php/utils/docker/debian/docker-php-dev-mode /usr/local/bin/docker-php-dev-mode
+RUN dev-mode && rm -rf /usr/local/bin/dev-mode && rm -rf /usr/local/bin/docker-php-dev-mode
+
+# Install composer
+COPY src/php/utils/install-composer /usr/local/bin/
+RUN apt-get update \
+    && yes | apt-get install wget \
+    && install-composer \
+    && yes | apt-get purge wget \
+    && rm -rf /usr/local/bin/install-composer
+
+# Change entrypoint back to the default because we don't need shush in development
+ENTRYPOINT ["docker-php-entrypoint"]
+
+## NTS-DEV stage ##
+FROM nts-slim-dev-root AS nts-slim-dev
 USER app
 
-## nts stage ##
-FROM nts-root AS nts
+FROM nts-dev-root AS nts-dev
+USER app
 
+## NTS stage ##
+FROM nts-slim-root AS nts-slim
+USER app
+
+FROM nts-root AS nts
 USER app

--- a/Dockerfile-zts-alpine
+++ b/Dockerfile-zts-alpine
@@ -13,7 +13,7 @@ RUN git fetch \
     cp "$EXTENSION_DIR/uv.so" /uv.so
 RUN sha256sum /uv.so
 
-FROM php:7.4-zts-alpine3.11 AS zts-root
+FROM php:7.4-zts-alpine3.11 AS zts-slim-root
 
 # Build-time metadata as defined at http://label-schema.org
 LABEL org.label-schema.name="wyrihaximusnet/php" \
@@ -43,9 +43,6 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
 	mv /*.so "$EXTENSION_DIR/" && \
 	apk update && \
 	apk add --no-cache \
-        freetype-dev \
-        libjpeg-turbo-dev \
-        libpng-dev \
         gmp-dev \
         zlib-dev \
         postgresql-dev \
@@ -57,19 +54,14 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
         bash \
         coreutils \
         procps \
-        vips-dev \
         git \
         $PHPIZE_DEPS \
     ## Install PECL
     && wget pear.php.net/go-pear.phar && php go-pear.phar \
-    ## Initially this was an if statement to check for PHP 7.4, but since then the situation change so we're just going to try both to avoid the conditional growing out of hand
-    && (docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/) \
-    && docker-php-ext-install -j$(nproc) gd pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache \
-    && pecl install vips \
+    && docker-php-ext-install -j$(nproc) pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache \
     && pecl install parallel \
     && docker-php-ext-enable parallel \
     && docker-php-ext-enable uv \
-    && docker-php-ext-enable vips \
     && apk del $PHPIZE_DEPS \
     && wget -O - https://raw.githubusercontent.com/eficode/wait-for/master/wait-for > /bin/wait-for \
     && chmod +x /bin/wait-for \
@@ -85,40 +77,54 @@ STOPSIGNAL SIGTERM
 ENTRYPOINT ["/usr/local/bin/shush", "exec", "docker-php-entrypoint"]
 
 ## ZTS-DEV STAGE ##
+FROM zts-slim-root AS zts-root
+
+# Install ext-gd and ext-vips
+COPY src/php/utils/docker/alpine/install-gd-and-vips /usr/local/bin/install-gd-and-vips
+RUN install-gd-and-vips && rm -rf /usr/local/bin/install-gd-and-vips
+
+## ZTS-DEV STAGE ##
+FROM zts-slim-root AS zts-slim-dev-root
+
+RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
+
+# Install docker help scripts
+COPY src/php/utils/docker/alpine/dev-mode /usr/local/bin/dev-mode
+RUN dev-mode && rm -rf /usr/local/bin/dev-mode
+
+# Install composer
+COPY src/php/utils/install-composer /usr/local/bin/
+RUN install-composer && rm -rf /usr/local/bin/install-composer
+
+# Change entrypoint back to the default because we don't need shush in development
+ENTRYPOINT ["docker-php-entrypoint"]
+
+## ZTS-DEV STAGE ##
 FROM zts-root AS zts-dev-root
 
 RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
 
 # Install docker help scripts
-COPY src/php/utils/docker/alpine/ /usr/local/bin/
-
-RUN apk add --no-cache \
-        make \
-        git \
-        openssh-client \
-        bash \
-        strace \
-        gdb \
-# Install Xdebug and development specific configuration
-    && docker-php-dev-mode xdebug \
-    && docker-php-dev-mode config \
-# Forcefully clear API cache
-    && rm -rf /var/cache/apk/*
+COPY src/php/utils/docker/alpine/dev-mode /usr/local/bin/dev-mode
+RUN dev-mode && rm -rf /usr/local/bin/dev-mode
 
 # Install composer
 COPY src/php/utils/install-composer /usr/local/bin/
-RUN install-composer \
-    && rm -rf /usr/local/bin/install-composer
+RUN install-composer && rm -rf /usr/local/bin/install-composer
 
 # Change entrypoint back to the default because we don't need shush in development
 ENTRYPOINT ["docker-php-entrypoint"]
 
 ## ZTS-DEV stage ##
-FROM zts-dev-root AS zts-dev
+FROM zts-slim-dev-root AS zts-slim-dev
+USER app
 
+FROM zts-dev-root AS zts-dev
 USER app
 
 ## ZTS stage ##
-FROM zts-root AS zts
+FROM zts-slim-root AS zts-slim
+USER app
 
+FROM zts-root AS zts
 USER app

--- a/Dockerfile-zts-debian
+++ b/Dockerfile-zts-debian
@@ -27,7 +27,7 @@ RUN git fetch \
     cp "$EXTENSION_DIR/uv.so" /uv.so
 RUN sha256sum /uv.so
 
-FROM php:7.4-zts-buster AS zts-root
+FROM php:7.4-zts-buster AS zts-slim-root
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
@@ -64,9 +64,6 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
 	apt-get update && \
 	yes | apt-get upgrade && \
     yes | apt-get install \
-        libfreetype6-dev \
-        libjpeg62-turbo-dev \
-        libpng-dev \
         libgmp-dev \
         zlib1g-dev \
         libpq-dev \
@@ -78,17 +75,13 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
         bash \
         coreutils \
         procps \
-        libvips-dev \
         git \
         wget \
         gdb \
         $PHPIZE_DEPS \
-    && (docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/) \
-    && docker-php-ext-install -j$(nproc) gd pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv \
-    && pecl install vips \
+    && docker-php-ext-install -j$(nproc) pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv \
     && docker-php-ext-enable parallel \
     && docker-php-ext-enable uv \
-    && docker-php-ext-enable vips \
     && wget -O - https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /bin/wait-for \
     && yes | apt-get purge wget $PHPIZE_DEPS \
     && chmod +x /bin/wait-for \
@@ -104,25 +97,42 @@ STOPSIGNAL SIGTERM
 ENTRYPOINT ["/usr/local/bin/shush", "exec", "docker-php-entrypoint"]
 
 ## ZTS-DEV STAGE ##
+FROM zts-slim-root AS zts-root
+
+# Install ext-gd and ext-vips
+COPY src/php/utils/docker/debian/install-gd-and-vips /usr/local/bin/install-gd-and-vips
+RUN install-gd-and-vips && rm -rf /usr/local/bin/install-gd-and-vips
+
+## ZTS-DEV STAGE ##
+FROM zts-slim-root AS zts-slim-dev-root
+
+RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
+
+# Install docker help scripts
+COPY src/php/utils/docker/debian/dev-mode /usr/local/bin/dev-mode
+COPY src/php/utils/docker/debian/docker-php-dev-mode /usr/local/bin/docker-php-dev-mode
+RUN dev-mode && rm -rf /usr/local/bin/dev-mode && rm -rf /usr/local/bin/docker-php-dev-mode
+
+# Install composer
+COPY src/php/utils/install-composer /usr/local/bin/
+RUN apt-get update \
+    && yes | apt-get install wget \
+    && install-composer \
+    && yes | apt-get purge wget \
+    && rm -rf /usr/local/bin/install-composer
+
+# Change entrypoint back to the default because we don't need shush in development
+ENTRYPOINT ["docker-php-entrypoint"]
+
+## ZTS-DEV STAGE ##
 FROM zts-root AS zts-dev-root
 
 RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
 
 # Install docker help scripts
-COPY src/php/utils/docker/ /usr/local/bin/
-
-RUN apt-get update \
-    && yes | apt-get install \
-        make \
-        git \
-        openssh-client \
-        bash \
-        strace \
-# Install Xdebug and development specific configuration
-    && docker-php-dev-mode xdebug \
-    && docker-php-dev-mode config \
-# Forcefully clear API cache
-    && rm -rf /var/cache/apk/*
+COPY src/php/utils/docker/debian/dev-mode /usr/local/bin/dev-mode
+COPY src/php/utils/docker/debian/docker-php-dev-mode /usr/local/bin/docker-php-dev-mode
+RUN dev-mode && rm -rf /usr/local/bin/dev-mode && rm -rf /usr/local/bin/docker-php-dev-mode
 
 # Install composer
 COPY src/php/utils/install-composer /usr/local/bin/
@@ -136,11 +146,15 @@ RUN apt-get update \
 ENTRYPOINT ["docker-php-entrypoint"]
 
 ## ZTS-DEV stage ##
-FROM zts-dev-root AS zts-dev
+FROM zts-slim-dev-root AS zts-slim-dev
+USER app
 
+FROM zts-dev-root AS zts-dev
 USER app
 
 ## ZTS stage ##
-FROM zts-root AS zts
+FROM zts-slim-root AS zts-slim
+USER app
 
+FROM zts-root AS zts
 USER app

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ In order to provide upgrade path we intend to keep one or more versions of PHP.
 
 The tag naming strategy consists of (Read as a regex):
 
-- PHP: `(phpMajor).(phpMinor)-(nts|zts)-(alpine(alpineMajor).(alpineMinor)|buster|strech)(-dev)(-root)?`
-  - Example: `7.2-fpm-alpine3.8`, `7.2-fpm-alpine3.8-dev`, `8.0-zts-buster`
+- PHP: `(phpMajor).(phpMinor)-(nts|zts)-(alpine(alpineMajor).(alpineMinor)|buster|strech)(-slim)(-dev)(-root)?`
+  - Example: `7.2-fpm-alpine3.8`, `7.2-fpm-alpine3.8-dev`, `8.0-zts-buster-slim`
 
 
 ### NTS
@@ -94,6 +94,13 @@ Both versions come with the following list of non-non-blocking related (core-) e
 * xmlwriter
 * zip
 * zlib
+
+# Slim images
+
+Slim images include all the above extensions except the following, as those notoriously require heavy dependencies:
+
+* gd
+* vips
 
 # Credits
 

--- a/build-php.sh
+++ b/build-php.sh
@@ -24,6 +24,10 @@ declare -r WYRIHAXIMUSNET_TAG="wyrihaximusnet/php:${VERSION_PHP}-${DST_IMAGE}-${
 declare -r WYRIHAXIMUSNET_TAG_DEV="${WYRIHAXIMUSNET_TAG}-dev"
 declare -r WYRIHAXIMUSNET_TAG_ROOT="${WYRIHAXIMUSNET_TAG}-root"
 declare -r WYRIHAXIMUSNET_TAG_DEV_ROOT="${WYRIHAXIMUSNET_TAG}-dev-root"
+declare -r WYRIHAXIMUSNET_TAG_SLIM="${WYRIHAXIMUSNET_TAG}-slim"
+declare -r WYRIHAXIMUSNET_TAG_SLIM_DEV="${WYRIHAXIMUSNET_TAG}-slim-dev"
+declare -r WYRIHAXIMUSNET_TAG_SLIM_ROOT="${WYRIHAXIMUSNET_TAG}-slim-root"
+declare -r WYRIHAXIMUSNET_TAG_SLIM_DEV_ROOT="${WYRIHAXIMUSNET_TAG}-slim-dev-root"
 
 declare -r TAG_FILE="./docker-image/image.tags"
 
@@ -38,3 +42,15 @@ sed -E "s/${IMAGE_ORIGINAL_TAG}/${IMAGE_TAG}/g" "Dockerfile-${DST_IMAGE}-${OS}" 
 
 sed -E "s/${IMAGE_ORIGINAL_TAG}/${IMAGE_TAG}/g" "Dockerfile-${DST_IMAGE}-${OS}" | docker build --pull --label org.label-schema.build-date=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --label org.label-schema.vcs-ref=`git rev-parse --short HEAD` -t "${WYRIHAXIMUSNET_TAG_DEV_ROOT}" --target="${DST_IMAGE}-dev-root" -f - . \
     && echo "$WYRIHAXIMUSNET_TAG_DEV_ROOT" >> "$TAG_FILE"
+
+sed -E "s/${IMAGE_ORIGINAL_TAG}/${IMAGE_TAG}/g" "Dockerfile-${DST_IMAGE}-${OS}" | docker build --pull --label org.label-schema.build-date=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --label org.label-schema.vcs-ref=`git rev-parse --short HEAD` -t "${WYRIHAXIMUSNET_TAG_SLIM}" --target="${DST_IMAGE}-slim" -f - . \
+    && echo "$WYRIHAXIMUSNET_TAG_SLIM" >> "$TAG_FILE"
+
+sed -E "s/${IMAGE_ORIGINAL_TAG}/${IMAGE_TAG}/g" "Dockerfile-${DST_IMAGE}-${OS}" | docker build --pull --label org.label-schema.build-date=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --label org.label-schema.vcs-ref=`git rev-parse --short HEAD` -t "${WYRIHAXIMUSNET_TAG_SLIM_DEV}" --target="${DST_IMAGE}-slim-dev" -f - . \
+    && echo "$WYRIHAXIMUSNET_TAG_SLIM_DEV" >> "$TAG_FILE"
+
+sed -E "s/${IMAGE_ORIGINAL_TAG}/${IMAGE_TAG}/g" "Dockerfile-${DST_IMAGE}-${OS}" | docker build --pull --label org.label-schema.build-date=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --label org.label-schema.vcs-ref=`git rev-parse --short HEAD` -t "${WYRIHAXIMUSNET_TAG_SLIM_ROOT}" --target="${DST_IMAGE}-slim-root" -f - . \
+    && echo "$WYRIHAXIMUSNET_TAG_SLIM_ROOT" >> "$TAG_FILE"
+
+sed -E "s/${IMAGE_ORIGINAL_TAG}/${IMAGE_TAG}/g" "Dockerfile-${DST_IMAGE}-${OS}" | docker build --pull --label org.label-schema.build-date=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --label org.label-schema.vcs-ref=`git rev-parse --short HEAD` -t "${WYRIHAXIMUSNET_TAG_SLIM_DEV_ROOT}" --target="${DST_IMAGE}-slim-dev-root" -f - . \
+    && echo "$WYRIHAXIMUSNET_TAG_SLIM_DEV_ROOT" >> "$TAG_FILE"

--- a/src/php/utils/docker/alpine/dev-mode
+++ b/src/php/utils/docker/alpine/dev-mode
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -xe
+
+apk add --no-cache make git openssh-client bash strace gdb
+# Install Xdebug and development specific configuration
+docker-php-dev-mode xdebug
+docker-php-dev-mode config
+# Forcefully clear API cache
+rm -rf /var/cache/apk/*

--- a/src/php/utils/docker/alpine/install-gd-and-vips
+++ b/src/php/utils/docker/alpine/install-gd-and-vips
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -xe
+
+apk update
+apk add --no-cache freetype-dev libjpeg-turbo-dev libpng-dev vips-dev $PHPIZE_DEPS
+## Initially this was an if statement to check for PHP 7.4, but since then the situation change so we're just going to try both to avoid the conditional growing out of hand
+(docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/)
+docker-php-ext-install -j$(nproc) gd
+pecl install vips
+docker-php-ext-enable vips
+rm -rf /var/cache/apk/*
+rm -rf /tmp/*

--- a/src/php/utils/docker/debian/dev-mode
+++ b/src/php/utils/docker/debian/dev-mode
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -xe
+
+apt-get update
+yes | apt-get install make git openssh-client bash strace
+# Install Xdebug and development specific configuration
+docker-php-dev-mode xdebug
+docker-php-dev-mode config
+# Forcefully clear API cache
+rm -rf /var/cache/apk/*

--- a/src/php/utils/docker/debian/install-gd-and-vips
+++ b/src/php/utils/docker/debian/install-gd-and-vips
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -xe
+
+apt-get update
+yes | apt-get install  libfreetype6-dev libjpeg62-turbo-dev libpng-dev libvips-dev $PHPIZE_DEPS
+## Initially this was an if statement to check for PHP 7.4, but since then the situation change so we're just going to try both to avoid the conditional growing out of hand
+(docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/)
+docker-php-ext-install -j$(nproc) gd
+pecl install vips
+docker-php-ext-enable vips
+rm -rf /var/cache/apt/*
+rm -rf /tmp/*

--- a/test-nts.sh
+++ b/test-nts.sh
@@ -19,6 +19,12 @@ else
     TEST_SUITE="php_nts or php_no_dev and not php_dev"
 fi
 
+if [[ $DOCKER_TAG == *"-slim"* ]]; then
+    TEST_SUITE="php_slim or $TEST_SUITE"
+else
+    TEST_SUITE="php_not_slim or $TEST_SUITE"
+fi
+
 if [[ $DOCKER_TAG == *"-root"* ]]; then
     TEST_SUITE="php_root or $TEST_SUITE"
 else

--- a/test-zts.sh
+++ b/test-zts.sh
@@ -19,6 +19,12 @@ else
     TEST_SUITE="php_zts or php_no_dev and not php_dev"
 fi
 
+if [[ $DOCKER_TAG == *"-slim"* ]]; then
+    TEST_SUITE="php_slim or $TEST_SUITE"
+else
+    TEST_SUITE="php_not_slim or $TEST_SUITE"
+fi
+
 if [[ $DOCKER_TAG == *"-root"* ]]; then
     TEST_SUITE="php_root or $TEST_SUITE"
 else

--- a/test/container/test_php.py
+++ b/test/container/test_php.py
@@ -64,8 +64,7 @@ def test_php_ext_uv_is_functional(host):
     assert output.stdout == '0123finished'
     assert output.rc == 0
 
-@pytest.mark.php_nts
-@pytest.mark.php_zts
+@pytest.mark.php_not_slim
 def test_php_ext_vips_is_enabled(host):
     output = host.run('php -r "exit(function_exists(\'vips_version\') ? 0 : 255);"')
     assert output.rc == 0

--- a/test/container/test_php_ext.py
+++ b/test/container/test_php_ext.py
@@ -5,8 +5,7 @@ import pytest
 def test_bcmath_is_loaded(host):
     assert 'bcmath' in host.run('php -m').stdout
 
-@pytest.mark.php_zts
-@pytest.mark.php_nts
+@pytest.mark.php_not_slim
 def test_gd_is_loaded(host):
     assert 'gd' in host.run('php -m').stdout
 
@@ -45,8 +44,7 @@ def test_pgsql_is_loaded(host):
 def test_uv_is_loaded(host):
     assert 'uv' in host.run('php -m').stdout
 
-@pytest.mark.php_zts
-@pytest.mark.php_nts
+@pytest.mark.php_not_slim
 def test_vips_is_loaded(host):
     assert 'vips' in host.run('php -m').stdout
 


### PR DESCRIPTION
ext-gd, ext-vips, and in the future ext-intl bring in huge
dependencies, on Alpine that was manageable, but on Debian they add
900MB+ per image and doesn't suite all uses cases.