### PR TITLE
Get up to 1000 of our own images

### DIFF
--- a/utils/all-images.php
+++ b/utils/all-images.php
@@ -7,10 +7,13 @@ foreach (range(1, 10) as $i) {
         $upstreamImages[$image['name']] = new DateTimeImmutable($image['last_updated']);
     }
 }
+
 $images = [];
-$json = json_decode(file_get_contents('https://hub.docker.com/v2/repositories/wyrihaximusnet/php/tags?page_size=100'), true);
-foreach ($json['results'] as $image) {
-    $images[$image['name']] = new DateTimeImmutable($image['last_updated']);
+foreach (range(1, 10) as $i) {
+    $json = json_decode(file_get_contents('https://hub.docker.com/v2/repositories/wyrihaximusnet/php/tags?page_size=100&page=' . $i), true);
+    foreach ($json['results'] as $image) {
+        $images[$image['name']] = new DateTimeImmutable($image['last_updated']);
+    }
 }
 
 $output = [];

--- a/utils/newer-upstream-images.php
+++ b/utils/newer-upstream-images.php
@@ -7,10 +7,13 @@ foreach (range(1, 10) as $i) {
         $upstreamImages[$image['name']] = new DateTimeImmutable($image['last_updated']);
     }
 }
+
 $images = [];
-$json = json_decode(file_get_contents('https://hub.docker.com/v2/repositories/wyrihaximusnet/php/tags?page_size=100'), true);
-foreach ($json['results'] as $image) {
-    $images[$image['name']] = new DateTimeImmutable($image['last_updated']);
+foreach (range(1, 10) as $i) {
+    $json = json_decode(file_get_contents('https://hub.docker.com/v2/repositories/wyrihaximusnet/php/tags?page_size=100&page=' . $i), true);
+    foreach ($json['results'] as $image) {
+        $images[$image['name']] = new DateTimeImmutable($image['last_updated']);
+    }
 }
 
 $output = [];


### PR DESCRIPTION
This is to compare with the list of upstream Docker Hub images. Not
doing this is causing a specific set of images being created and pushed
every two hours. That happens because our own set of images has grown
beyond 100 different tags.