### PR TITLE
Don't create image type matrix until we build the image matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
   image-type-matrix:
     name: Create Image Type Matrix
     runs-on: ubuntu-latest
+    needs:
+      - image-matrix
     outputs:
       type: ${{ steps.image-type-matrix.outputs.type }}
     steps:


### PR DESCRIPTION
No need to run extra jobs when we don't run the full build and test workflow