### PR TITLE
Temporary disable automatic PHP version detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
     steps:
       - id: supported-php-versions
         name: Generate PHP
-        uses: wyrihaximus/github-action-supported-php-versions@v1
+        run: |
+          echo "Found the following versions: ["7.3", "7.4"]\r\n"
+          echo "::set-output name=versions::["7.3", "7.4"]"
   registry-matrix:
     name: Extract registries from registry secret mapping
     if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master'


### PR DESCRIPTION
Main reason is that there currently is a CVE in tar and that's blocking
pipelines. Plus building images for PHP 8 is broken due to ext-parallel
changes. Filing a PR very soon for that.