### PR TITLE
Only rebuild images once a day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron:  '33 */4 * * *'
+    - cron:  '13 4 * * *'
 jobs:
   supported-alpine-versions:
     name: Supported Alpine versions


### PR DESCRIPTION
Only rebuild images once a day when required instead of every four hours. This will prepare for #158 that will have longer run through times due to building for other archs than `amd64`