### PR TITLE
Update ext-uv repository location

### DIFF
--- a/Dockerfile-nts-alpine
+++ b/Dockerfile-nts-alpine
@@ -22,7 +22,7 @@ FROM base AS base-build
 RUN apk add --no-cache $PHPIZE_DEPS git libuv-dev
 
 FROM base-build AS build-uv
-RUN git clone https://github.com/bwoebi/php-uv uv
+RUN git clone https://github.com/amphp/php-uv uv
 WORKDIR /uv
 RUN git fetch \
     && git pull \

--- a/Dockerfile-nts-debian
+++ b/Dockerfile-nts-debian
@@ -22,7 +22,7 @@ FROM base AS base-build
 RUN yes | apt-get install $PHPIZE_DEPS git libuv1-dev
 
 FROM base-build AS build-uv
-RUN git clone https://github.com/bwoebi/php-uv uv
+RUN git clone https://github.com/amphp/php-uv uv
 WORKDIR /uv
 RUN git fetch \
     && git pull \

--- a/Dockerfile-zts-alpine
+++ b/Dockerfile-zts-alpine
@@ -22,7 +22,7 @@ FROM base AS base-build
 RUN apk add --no-cache $PHPIZE_DEPS git libuv-dev
 
 FROM base-build AS build-uv
-RUN git clone https://github.com/bwoebi/php-uv uv
+RUN git clone https://github.com/amphp/php-uv uv
 WORKDIR /uv
 RUN git fetch \
     && git pull \

--- a/Dockerfile-zts-debian
+++ b/Dockerfile-zts-debian
@@ -22,7 +22,7 @@ FROM base AS base-build
 RUN yes | apt-get install $PHPIZE_DEPS git libuv1-dev
 
 FROM base-build AS build-uv
-RUN git clone https://github.com/bwoebi/php-uv uv
+RUN git clone https://github.com/amphp/php-uv uv
 WORKDIR /uv
 RUN git fetch \
     && git pull \


### PR DESCRIPTION
It shouldn't matter because GitHub will redirect, but still it might get hijacked, and we don't want to risk that.