### PR TITLE
Temporary turning off daily checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron:  '13 4 * * *'
+#  schedule:
+#    - cron:  '13 4 * * *'
 jobs:
   supported-alpine-versions:
     name: Supported Alpine versions


### PR DESCRIPTION
Due to the way multi arch images are being built in the next few days I need to update some scripts. So turning the early morning builds of the images off until then.