### PR TITLE
Temporary don't build fat images (with GD and VIPS)

### DIFF
--- a/build-php.sh
+++ b/build-php.sh
@@ -38,10 +38,10 @@ declare -r WYRIHAXIMUSNET_TAG_SLIM_DEV_ROOT="${WYRIHAXIMUSNET_TAG}-slim-dev-root
 declare -r TAG_FILE="./docker-image/image.tags"
 
 declare -a target=(
-  ""
-  "-dev"
-  "-root"
-  "-dev-root"
+#  ""
+#  "-dev"
+#  "-root"
+#  "-dev-root"
   "-slim"
   "-slim-dev"
   "-slim-root"


### PR DESCRIPTION
This will ensure the other tags have at least 8.1.0 out there