### PR TITLE
Update README examples to use ghcr.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ docker build . -t IMAGE_NAME:TAG --target=runtime
 ```
 
 ```dockerfile
-FROM wyrihaximusnet/php:7.4-zts-alpine-slim-dev AS install-dependencies
+FROM ghcr.io/wyrihaximusnet/php:7.4-zts-alpine-slim-dev AS install-dependencies
 
 WORKDIR /opt/app
 
@@ -60,7 +60,7 @@ COPY ./composer.json /opt/app/composer.json
 COPY ./src/ /opt/app/src/
 RUN composer install --ansi --no-interaction --prefer-dist --no-dev -o
 
-FROM wyrihaximusnet/php:7.4-zts-alpine-slim AS runtime
+FROM ghcr.io/wyrihaximusnet/php:7.4-zts-alpine-slim AS runtime
 
 WORKDIR /opt/app
 


### PR DESCRIPTION
Given Docker's continuous teardown of Docker Hub, updating the examples to a more reliable registry should provide the same solid experience.