### PR TITLE
Stop building Debian images

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,14 +1,14 @@
 name: Debian
 on:
   workflow_dispatch:
-  push:
-    paths-ignore:
-      - 'README.md'
-    branches:
-      - master
-  pull_request:
-  schedule:
-    - cron:  '13 4 * * *'
+#  push:
+#    paths-ignore:
+#      - 'README.md'
+#    branches:
+#      - master
+#  pull_request:
+#  schedule:
+#    - cron:  '13 4 * * *'
 jobs:
   supported-debian-versions:
     name: Supported Debian versions


### PR DESCRIPTION
These have been failing for over a year+, and I haven't received any complaints/issues/etc about it. Once the package page is fully back in working condition I'll check if anyone is using them and if not fully drop them.