### PR TITLE
Increase JIT buffer size to next logical unit

### DIFF
--- a/src/php/cli/conf/jit.ini
+++ b/src/php/cli/conf/jit.ini
@@ -1,3 +1,3 @@
 opcache.enable_cli=1
-opcache.jit_buffer_size=100M
+opcache.jit_buffer_size=128M
 opcache.jit=1255


### PR DESCRIPTION
It's configured to be `100M` now, which results in:
```
opcache.jit_buffer_size => 64M => 64M
```

By setting it to `128M` we get the full `128MB`