### PR TITLE
Revert disabling OTEL on dev images

### DIFF
--- a/Dockerfile-nts-alpine
+++ b/Dockerfile-nts-alpine
@@ -49,7 +49,7 @@ RUN git fetch \
     && cp "$EXTENSION_DIR/uv.so" /uv.so \
     && sha256sum /uv.so
 
-FROM base AS nts-pre-slim-root
+FROM base AS nts-slim-root
 
 COPY --from=build-uv /uv.so /uv.so
 
@@ -73,7 +73,7 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
         $PHPIZE_DEPS \
     ## Install PECL
     && wget -q pear.php.net/go-pear.phar && php go-pear.phar \
-    && install-php-extensions pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache intl sockets \
+    && install-php-extensions pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache intl sockets ffi opentelemetry grpc \
     && (install-php-extensions random || true) \
     && (pecl install eio || pecl install eio-beta) \
     && docker-php-ext-enable eio \
@@ -91,24 +91,16 @@ STOPSIGNAL SIGTERM
 
 ENTRYPOINT ["docker-php-entrypoint"]
 
-FROM nts-pre-slim-root AS nts-slim-root
-
-RUN install-php-extensions ffi opentelemetry grpc
-
 ## NTS-DEV STAGE ##
-FROM nts-pre-slim-root  AS nts-pre-root
+FROM nts-slim-root  AS nts-root
 
 # Install ext-gd and ext-vips
 COPY src/php/utils/docker/alpine/install-gd-and-vips /usr/local/bin/install-gd-and-vips
 RUN if [ $(php -v | grep "alpha\|ALPHA\|beta\|BETA\|rc\|RC" | wc -l) != 0 ] ; then true ; else install-gd-and-vips; fi \
      && rm -rf /usr/local/bin/install-gd-and-vips
 
-FROM nts-pre-root AS nts-root
-
-RUN install-php-extensions ffi opentelemetry grpc
-
 ## NTS-DEV STAGE ##
-FROM nts-pre-slim-root AS nts-slim-dev-root
+FROM nts-slim-root AS nts-slim-dev-root
 
 RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
 
@@ -127,7 +119,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 ENTRYPOINT ["docker-php-entrypoint"]
 
 ## NTS-DEV STAGE ##
-FROM nts-pre-root AS nts-dev-root
+FROM nts-root AS nts-dev-root
 
 RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
 

--- a/Dockerfile-zts-alpine
+++ b/Dockerfile-zts-alpine
@@ -49,7 +49,7 @@ RUN git fetch \
     && cp "$EXTENSION_DIR/uv.so" /uv.so \
     && sha256sum /uv.so
 
-FROM base AS zts-pre-slim-root
+FROM base AS zts-slim-root
 
 COPY --from=build-uv /uv.so /uv.so
 
@@ -77,7 +77,7 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
         $PHPIZE_DEPS \
     ## Install PECL
     && wget -q pear.php.net/go-pear.phar && php go-pear.phar \
-    && install-php-extensions pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache intl sockets \
+    && install-php-extensions pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache intl sockets ffi opentelemetry grpc \
     && (install-php-extensions random || true) \
     && pecl install parallel || pecl install parallel-1.1.4 \
     && docker-php-ext-enable parallel \
@@ -97,24 +97,16 @@ STOPSIGNAL SIGTERM
 
 ENTRYPOINT ["docker-php-entrypoint"]
 
-FROM zts-pre-slim-root AS zts-slim-root
-
-RUN install-php-extensions ffi opentelemetry grpc
-
 ## ZTS-DEV STAGE ##
-FROM zts-pre-slim-root AS zts-pre-root
+FROM zts-slim-root AS zts-root
 
 # Install ext-gd and ext-vips
 COPY src/php/utils/docker/alpine/install-gd-and-vips /usr/local/bin/install-gd-and-vips
 RUN if [ $(php -v | grep "alpha\|ALPHA\|beta\|BETA\|rc\|RC" | wc -l) != 0 ] ; then true ; else install-gd-and-vips; fi \
      && rm -rf /usr/local/bin/install-gd-and-vips
 
-FROM zts-pre-root AS zts-root
-
-RUN install-php-extensions ffi opentelemetry grpc
-
 ## ZTS-DEV STAGE ##
-FROM zts-pre-slim-root AS zts-slim-dev-root
+FROM zts-slim-root AS zts-slim-dev-root
 
 RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
 
@@ -129,7 +121,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 ENTRYPOINT ["docker-php-entrypoint"]
 
 ## ZTS-DEV STAGE ##
-FROM zts-pre-root AS zts-dev-root
+FROM zts-root AS zts-dev-root
 
 RUN touch /.you-are-in-a-wyrihaximus.net-php-docker-image-dev
 

--- a/test/container/test_php_otel.py
+++ b/test/container/test_php_otel.py
@@ -1,25 +1,16 @@
 import pytest
 
-@pytest.mark.php_dev
-def test_ffs_is_loaded(host):
-    assert 'FFI' not in host.run('php -m').stdout
-
-@pytest.mark.php_dev
-def test_grpc_is_loaded(host):
-    assert 'grpc' not in host.run('php -m').stdout
-
-@pytest.mark.php_dev
-def test_opentelemetry_is_loaded(host):
-    assert 'opentelemetry' not in host.run('php -m').stdout
-
-@pytest.mark.php_no_dev
+@pytest.mark.php_nts
+@pytest.mark.php_zts
 def test_ffs_is_loaded(host):
     assert 'FFI' in host.run('php -m').stdout
 
-@pytest.mark.php_no_dev
+@pytest.mark.php_nts
+@pytest.mark.php_zts
 def test_grpc_is_loaded(host):
     assert 'grpc' in host.run('php -m').stdout
 
-@pytest.mark.php_no_dev
+@pytest.mark.php_nts
+@pytest.mark.php_zts
 def test_opentelemetry_is_loaded(host):
     assert 'opentelemetry' in host.run('php -m').stdout


### PR DESCRIPTION
This was a mistake, need to fix using fibers in unit tests a better way. Not the responsibility of this image