### PR TITLE
Drop GRPC from 8.5 and up

### DIFF
--- a/Dockerfile-nts-alpine
+++ b/Dockerfile-nts-alpine
@@ -76,7 +76,8 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
         $PHPIZE_DEPS \
     ## Install PECL
     && wget -q pear.php.net/go-pear.phar && php go-pear.phar \
-    && install-php-extensions pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache intl sockets ffi opentelemetry grpc \
+    && install-php-extensions pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache intl sockets ffi opentelemetry \
+    && if [ $(php -v | grep "PHP 8.5" | wc -l) != 0 ] ; then true ; else install-php-extensions grpc; fi \
     && (install-php-extensions random || true) \
     && (pecl install eio || pecl install eio-beta) \
     && docker-php-ext-enable eio \

--- a/Dockerfile-zts-alpine
+++ b/Dockerfile-zts-alpine
@@ -80,7 +80,8 @@ RUN EXTENSION_DIR=`php-config --extension-dir 2>/dev/null` && \
         $PHPIZE_DEPS \
     ## Install PECL
     && wget -q pear.php.net/go-pear.phar && php go-pear.phar \
-    && install-php-extensions pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache intl sockets ffi opentelemetry grpc \
+    && install-php-extensions pcntl pgsql pdo pdo_pgsql bcmath zip gmp iconv opcache intl sockets ffi opentelemetry \
+    && if [ $(php -v | grep "PHP 8.5" | wc -l) != 0 ] ; then true ; else install-php-extensions grpc; fi \
     && (install-php-extensions random || true) \
     && pecl install parallel || pecl install parallel-1.1.4 \
     && docker-php-ext-enable parallel \

--- a/test/container/test_php_otel.py
+++ b/test/container/test_php_otel.py
@@ -7,10 +7,5 @@ def test_ffs_is_loaded(host):
 
 @pytest.mark.php_nts
 @pytest.mark.php_zts
-def test_grpc_is_loaded(host):
-    assert 'grpc' in host.run('php -m').stdout
-
-@pytest.mark.php_nts
-@pytest.mark.php_zts
 def test_opentelemetry_is_loaded(host):
     assert 'opentelemetry' in host.run('php -m').stdout


### PR DESCRIPTION
It's heavy, adding it in retro spec was a mistake as it blocked the event loop.